### PR TITLE
Add default trip duration input and increase minimum

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -22,7 +22,7 @@
   <%= f.date_field :departure_date, value: Date.today, min: Date.today %>
 
   <%= f.label :trip_duration, "Trip duration: " %>
-  <%= f.number_field :trip_duration, min: 0 %> days
+  <%= f.number_field :trip_duration, value: 1, min: 1 %> days
 
   <%= f.submit "Lucky Location" %>
 


### PR DESCRIPTION
This PR will:
* Add default value and improve minimum for trip duration number field input - this removes some possibilities for the user to make bad API calls

- [x] Repo Representation: Front End

- [x] Happy Path Tested

- [x] All Tests are passing

- [x] Collaborators: Sheryl Stillman
