### PR TITLE
Reformat show page

### DIFF
--- a/app/views/flights/show.html.erb
+++ b/app/views/flights/show.html.erb
@@ -1,15 +1,15 @@
 <h1>Flight Details</h1>
 
-  <p class="TripId"><%= @trip.flight_id %></p>
-  <p class="TripOrigin"><%= @trip.origin_city %></p>
-  <p class="TripDestination"><%= @trip.destination_city %></p>
+  <p class="Price">Price: $<%= @trip.price %></p>
+  <p class="TripOrigin">Origin City: <%= @trip.origin_city %></p>
+  <p class="TripDestination">Destination: <%= @trip.destination_city %></p>
   <p class="TripDepTime"><%= @trip.departure_datetime %></p>
   <p class="TripArrTime"><%= @trip.arrival_datetime %></p>
   <p class="TripRDepTime"><%= @trip.r_departure_datetime %></p>
   <p class="TripRArrTime"><%= @trip.r_arrival_datetime %></p>
-  <p class="TripFeels"><%= @trip.day_feels_like_f %></p>
-  <p class="TripWeatherDesc"><%= @trip.description %></p>
-  <p class="TripBooking"><%= @trip.booking_link %></p>
+  <p class="TripFeels">Temperature Feels Like: <%= @trip.day_feels_like_f.round(1) %> °F</p>
+  <p class="TripWeatherDesc">Weather Description: <%= @trip.description %></p>
+  <p class="TripBooking"><%= link_to "Click Here To Book", @trip.booking_link %></p>
 
 
   <p class="TripAirbnb">

--- a/spec/features/flights/show_spec.rb
+++ b/spec/features/flights/show_spec.rb
@@ -44,6 +44,8 @@ describe 'when I click on a link to show a specific flight' do
     expect(".TripFeels").to_not be_empty
     expect(".TripWeatherDesc").to_not be_empty
     expect(".TripBooking").to_not be_empty
+
+    expect(page).to have_link("Click Here To Book")
   end
 
   it "recieves an error if I navigate to an unknown flight id" do

--- a/spec/features/flights/show_spec.rb
+++ b/spec/features/flights/show_spec.rb
@@ -24,7 +24,7 @@ describe 'when I click on a link to show a specific flight' do
     click_link "Houston"
 
     expect(current_path).to eq(flight_show_path("242"))
-    expect(page).to have_css(".TripId")
+    expect(page).to have_css(".Price")
     expect(page).to have_css(".TripOrigin")
     expect(page).to have_css(".TripDestination")
     expect(page).to have_css(".TripDepTime")
@@ -34,7 +34,7 @@ describe 'when I click on a link to show a specific flight' do
     expect(page).to have_css(".TripFeels")
     expect(page).to have_css(".TripWeatherDesc")
     expect(page).to have_css(".TripBooking")
-    expect(".TripId").to_not be_empty
+    expect(".Price").to_not be_empty
     expect(".TripOrigin").to_not be_empty
     expect(".TripDestination").to_not be_empty
     expect(".TripDepTime").to_not be_empty


### PR DESCRIPTION
Adds price to show page, as well as some information for easier readability. We want to format the date/times for the flights, but waiting on wireframes.

- [x] Updated Files: flight show page

- [x] Repo Representation: Front End

- [x] Happy Path Tested

- [x] All Tests are passing

- [x] Collabotors: Nick, Sheryl
